### PR TITLE
Fix warnings exposed by GCC8; exposed a bug

### DIFF
--- a/src/target/arm_disassembler.c
+++ b/src/target/arm_disassembler.c
@@ -1496,7 +1496,7 @@ static int evaluate_misc_instr(uint32_t opcode,
 		}
 
 		/* SMLAW < y> */
-		if (((opcode & 0x00600000) == 0x00100000) && (x == 0)) {
+        if (((opcode & 0x00600000) == 0x00200000) && (x == 0)) {
 			uint8_t Rd, Rm, Rs, Rn;
 			instruction->type = ARM_SMLAWy;
 			Rd = (opcode & 0xf0000) >> 16;
@@ -1518,7 +1518,7 @@ static int evaluate_misc_instr(uint32_t opcode,
 		}
 
 		/* SMUL < x><y> */
-		if ((opcode & 0x00600000) == 0x00300000) {
+        if ((opcode & 0x00600000) == 0x00600000) {
 			uint8_t Rd, Rm, Rs;
 			instruction->type = ARM_SMULxy;
 			Rd = (opcode & 0xf0000) >> 16;
@@ -1539,7 +1539,7 @@ static int evaluate_misc_instr(uint32_t opcode,
 		}
 
 		/* SMULW < y> */
-		if (((opcode & 0x00600000) == 0x00100000) && (x == 1)) {
+        if (((opcode & 0x00600000) == 0x00200000) && (x == 1)) {
 			uint8_t Rd, Rm, Rs;
 			instruction->type = ARM_SMULWy;
 			Rd = (opcode & 0xf0000) >> 16;


### PR DESCRIPTION
The ARM disassembler warnings actually exposed a bug in SMALW, SMULW and
SMUL instructions decoding.

changes lifted from:
https://sourceforge.net/p/openocd/code/ci/b50fa9a19d0b600d26b6cbca57cd94c7b89f941c

(only src/target/arm_disassembler.c, the other changes no longer exist)

Addresses this build failure: 
```
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I./src -I./src -I./src/helper -DPKGDATADIR=\"/usr/local/share/openocd\" -DBINDIR=\"/usr/local/bin\" -I./jimtcl -I./jimtcl -Wall -Wstrict-prototypes -Wformat-security -Wshadow -Wextra -Wno-unused-parameter -Wbad-function-cast -Wcast-align -Wredundant-decls -Werror -g -O2 -MT src/target/arm_disassembler.lo -MD -MP -MF src/target/.deps/arm_disassembler.Tpo -c src/target/arm_disassembler.c -o src/target/arm_disassembler.o
src/target/arm_disassembler.c: In function ‘evaluate_misc_instr’:
src/target/arm_disassembler.c:1499:30: error: bitwise comparison always evaluates to false [-Werror=tautological-compare]
   if (((opcode & 0x00600000) == 0x00100000) && (x == 0)) {
                              ^~
src/target/arm_disassembler.c:1521:29: error: bitwise comparison always evaluates to false [-Werror=tautological-compare]
   if ((opcode & 0x00600000) == 0x00300000) {
                             ^~
src/target/arm_disassembler.c:1542:30: error: bitwise comparison always evaluates to false [-Werror=tautological-compare]
   if (((opcode & 0x00600000) == 0x00100000) && (x == 1)) {
                              ^~
cc1: all warnings being treated as errors
```



